### PR TITLE
testall.g: don't set rewriteToFile by default

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,3 +1,3 @@
 LoadPackage("permut");
 dirs := DirectoriesPackageLibrary( "permut", "tst" );
-TestDirectory(dirs, rec(exitGAP := true, rewriteToFile:=true));
+TestDirectory(dirs, rec(exitGAP := true));


### PR DESCRIPTION
This file is supposed to detect changed test output, not to blindly
track it as the new reference output.
