### PR TITLE
PackageInfo.g: Use proper UTF-8 accents in authors' names

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -43,13 +43,12 @@ SetPackageInfo( rec(
                                      IsMaintainer:=false,
                                      Email:="Adolfo.Ballester@uv.es",
                                      PostalAddress:=Concatenation(
-                                                                  ["Adolfo Ballester-Bolinches\n",
-                                                                   "Departament de Matem\\`atiques\n",
-                                                                   "Universitat de Val\\`encia\n",
-                                                                   "Dr.\\ Moliner, 50\n",
-                                                                   "46100 Burjassot, Val\\`encia, Spain"]),
-                                     Place:="Burjassot, Val\\`encia",
-                                     Institution:="Departament de Matem\\`atiques, Universitat de Val\\`encia"
+                                                                  ["Departament de Matemàtiques\n",
+                                                                   "Universitat de València\n",
+                                                                   "Dr. Moliner, 50\n",
+                                                                   "46100 Burjassot, València, Spain"]),
+                                     Place:="Burjassot, València",
+                                     Institution:="Departament de Matemàtiques, Universitat de València"
                                     ),
                                 rec(
                                      LastName:="Cosme-Llópez",
@@ -59,13 +58,12 @@ SetPackageInfo( rec(
                                      WWWHome:="https://www.uv.es/coslloen",
                                      Email:="Enric.Cosme@uv.es",
                                      PostalAddress:=Concatenation(
-                                                                  ["Enric Cosme-Ll\\'opez\n",
-                                                                   "Departament de Matem\\`atiques\n",
-                                                                   "Universitat de Val\\`encia\n",
-                                                                   "Dr.\\ Moliner, 50\n",
-                                                                   "46100 Burjassot, Val\\`encia, Spain"]),
-                                     Place:="Burjassot, Val\\`encia",
-                                     Institution:="Departament de Matem\\`atiques, Universitat de Val\\`encia"
+                                                                  ["Departament de Matemàtiques\n",
+                                                                   "Universitat de València\n",
+                                                                   "Dr. Moliner, 50\n",
+                                                                   "46100 Burjassot, València, Spain"]),
+                                     Place:="Burjassot, València",
+                                     Institution:="Departament de Matemàtiques, Universitat de València"
                                     ),
                                 rec(
                                      LastName:="Esteban-Romero",
@@ -75,13 +73,12 @@ SetPackageInfo( rec(
                                      WWWHome:="https://www.uv.es/estebanr",
                                      Email:="Ramon.Esteban@uv.es",
                                      PostalAddres:=Concatenation(
-                                                                  ["Ramon Esteban-Romero\n",
-                                                                   "Departament de Matem\\`atiques\n",
-                                                                   "Universitat de Val\\`encia\n",
-                                                                   "Dr.\\ Moliner, 50\n",
-                                                                   "46100 Burjassot, Val\\`encia, Spain\n"]),
-                                     Place:="Burjassot, Val\\`encia",
-                                     Institution:="Departament de Matem\\`atiques, Universitat de Val\\`encia"
+                                                                  ["Departament de Matemàtiques\n",
+                                                                   "Universitat de València\n",
+                                                                   "Dr. Moliner, 50\n",
+                                                                   "46100 Burjassot, València, Spain\n"]),
+                                     Place:="Burjassot, València",
+                                     Institution:="Departament de Matemàtiques, Universitat de València"
                                     )
                      ],
                      


### PR DESCRIPTION
This essentially reverts a commit from 2018 whose commit message said:

> Change accented letters in names
>
> This is to have them shown correctly on the web page.

But it is not clear to me which website this refers to? If it is
<https://gap-packages.github.io/permut> then I don't see how UTF-8
should be a problem (plenty packages use it for their author names).
However it may be, but the TeX-style accents previously used definitely
won't be rendered in a useful way
